### PR TITLE
[Lobbies] Add schema and create, list operations

### DIFF
--- a/mf_backend/lib/mf_backend/lobby_context.ex
+++ b/mf_backend/lib/mf_backend/lobby_context.ex
@@ -1,0 +1,104 @@
+defmodule MfBackend.LobbyContext do
+  @moduledoc """
+  The LobbyContext context.
+  """
+
+  import Ecto.Query, warn: false
+  alias MfBackend.Repo
+
+  alias MfBackend.LobbyContext.Lobby
+
+  @doc """
+  Returns the list of lobbies.
+
+  ## Examples
+
+      iex> list_lobbies()
+      [%Lobby{}, ...]
+
+  """
+  def list_lobbies do
+    Repo.all(Lobby)
+  end
+
+  @doc """
+  Gets a single lobby.
+
+  Raises `Ecto.NoResultsError` if the Lobby does not exist.
+
+  ## Examples
+
+      iex> get_lobby!(123)
+      %Lobby{}
+
+      iex> get_lobby!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_lobby!(id), do: Repo.get!(Lobby, id)
+
+  @doc """
+  Creates a lobby.
+
+  ## Examples
+
+      iex> create_lobby(%{field: value})
+      {:ok, %Lobby{}}
+
+      iex> create_lobby(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_lobby(attrs \\ %{}) do
+    %Lobby{}
+    |> Lobby.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a lobby.
+
+  ## Examples
+
+      iex> update_lobby(lobby, %{field: new_value})
+      {:ok, %Lobby{}}
+
+      iex> update_lobby(lobby, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_lobby(%Lobby{} = lobby, attrs) do
+    lobby
+    |> Lobby.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a lobby.
+
+  ## Examples
+
+      iex> delete_lobby(lobby)
+      {:ok, %Lobby{}}
+
+      iex> delete_lobby(lobby)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_lobby(%Lobby{} = lobby) do
+    Repo.delete(lobby)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking lobby changes.
+
+  ## Examples
+
+      iex> change_lobby(lobby)
+      %Ecto.Changeset{data: %Lobby{}}
+
+  """
+  def change_lobby(%Lobby{} = lobby, attrs \\ %{}) do
+    Lobby.changeset(lobby, attrs)
+  end
+end

--- a/mf_backend/lib/mf_backend/lobby_context/lobby.ex
+++ b/mf_backend/lib/mf_backend/lobby_context/lobby.ex
@@ -1,0 +1,19 @@
+defmodule MfBackend.LobbyContext.Lobby do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @derive {Jason.Encoder, only: [:id, :name, :status]}
+  schema "lobbies" do
+    field :name, :string
+    field :status, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(lobby, attrs) do
+    lobby
+    |> cast(attrs, [:name, :status])
+    |> validate_required([:name, :status])
+  end
+end

--- a/mf_backend/lib/mf_backend_web/controllers/lobby_controller.ex
+++ b/mf_backend/lib/mf_backend_web/controllers/lobby_controller.ex
@@ -15,9 +15,15 @@ defmodule MfBackendWeb.LobbyController do
         |> put_status(:created)
         |> json(lobby)
       {:error, changeset} ->
+        errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+          Enum.reduce(opts, msg, fn {key, value}, acc ->
+            String.replace(acc, "%{#{key}}", to_string(value))
+          end)
+        end)
         conn
         |> put_status(:unprocessable_entity)
-        |> json(changeset)
+        |> json(%{"errors" => errors})
+        |> halt()
     end
   end
 end

--- a/mf_backend/lib/mf_backend_web/controllers/lobby_controller.ex
+++ b/mf_backend/lib/mf_backend_web/controllers/lobby_controller.ex
@@ -1,0 +1,23 @@
+defmodule MfBackendWeb.LobbyController do
+  use MfBackendWeb, :controller
+
+  alias MfBackend.LobbyContext
+
+  def index(conn, _params) do
+    lobbies = LobbyContext.list_lobbies()
+    json(conn, lobbies)
+  end
+
+  def create(conn, %{"lobby" => lobby_params}) do
+    case LobbyContext.create_lobby(lobby_params) do
+      {:ok, lobby} ->
+        conn
+        |> put_status(:created)
+        |> json(lobby)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(changeset)
+    end
+  end
+end

--- a/mf_backend/lib/mf_backend_web/router.ex
+++ b/mf_backend/lib/mf_backend_web/router.ex
@@ -20,10 +20,11 @@ defmodule MfBackendWeb.Router do
     get "/", PageController, :home
   end
 
-  # Other scopes may use custom stacks.
-  # scope "/api", MfBackendWeb do
-  #   pipe_through :api
-  # end
+  scope "/api", MfBackendWeb do
+    pipe_through :api
+
+    resources "/lobbies", LobbyController, only: [:index, :create, :edit]
+  end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development
   if Application.compile_env(:mf_backend, :dev_routes) do

--- a/mf_backend/priv/repo/migrations/20230720222843_create_lobbies.exs
+++ b/mf_backend/priv/repo/migrations/20230720222843_create_lobbies.exs
@@ -1,0 +1,12 @@
+defmodule MfBackend.Repo.Migrations.CreateLobbies do
+  use Ecto.Migration
+
+  def change do
+    create table(:lobbies) do
+      add :name, :string
+      add :status, :string
+
+      timestamps()
+    end
+  end
+end

--- a/mf_backend/test/mf_backend/lobby_context_test.exs
+++ b/mf_backend/test/mf_backend/lobby_context_test.exs
@@ -1,0 +1,61 @@
+defmodule MfBackend.LobbyContextTest do
+  use MfBackend.DataCase
+
+  alias MfBackend.LobbyContext
+
+  describe "lobbies" do
+    alias MfBackend.LobbyContext.Lobby
+
+    import MfBackend.LobbyContextFixtures
+
+    @invalid_attrs %{name: nil, status: nil}
+
+    test "list_lobbies/0 returns all lobbies" do
+      lobby = lobby_fixture()
+      assert LobbyContext.list_lobbies() == [lobby]
+    end
+
+    test "get_lobby!/1 returns the lobby with given id" do
+      lobby = lobby_fixture()
+      assert LobbyContext.get_lobby!(lobby.id) == lobby
+    end
+
+    test "create_lobby/1 with valid data creates a lobby" do
+      valid_attrs = %{name: "some name", status: "some status"}
+
+      assert {:ok, %Lobby{} = lobby} = LobbyContext.create_lobby(valid_attrs)
+      assert lobby.name == "some name"
+      assert lobby.status == "some status"
+    end
+
+    test "create_lobby/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = LobbyContext.create_lobby(@invalid_attrs)
+    end
+
+    test "update_lobby/2 with valid data updates the lobby" do
+      lobby = lobby_fixture()
+      update_attrs = %{name: "some updated name", status: "some updated status"}
+
+      assert {:ok, %Lobby{} = lobby} = LobbyContext.update_lobby(lobby, update_attrs)
+      assert lobby.name == "some updated name"
+      assert lobby.status == "some updated status"
+    end
+
+    test "update_lobby/2 with invalid data returns error changeset" do
+      lobby = lobby_fixture()
+      assert {:error, %Ecto.Changeset{}} = LobbyContext.update_lobby(lobby, @invalid_attrs)
+      assert lobby == LobbyContext.get_lobby!(lobby.id)
+    end
+
+    test "delete_lobby/1 deletes the lobby" do
+      lobby = lobby_fixture()
+      assert {:ok, %Lobby{}} = LobbyContext.delete_lobby(lobby)
+      assert_raise Ecto.NoResultsError, fn -> LobbyContext.get_lobby!(lobby.id) end
+    end
+
+    test "change_lobby/1 returns a lobby changeset" do
+      lobby = lobby_fixture()
+      assert %Ecto.Changeset{} = LobbyContext.change_lobby(lobby)
+    end
+  end
+end

--- a/mf_backend/test/mf_backend_web/controllers/lobby_controller_test.exs
+++ b/mf_backend/test/mf_backend_web/controllers/lobby_controller_test.exs
@@ -1,0 +1,46 @@
+defmodule MfBackendWeb.LobbyControllerTest do
+  use MfBackendWeb.ConnCase, async: true
+  alias MfBackend.LobbyContext
+
+  require Logger
+
+  @valid_attrs %{name: "my cool lobby", status: "open"}
+  @invalid_attrs %{name: nil, status: nil}
+
+  describe "index" do
+    test "returns 200 and list of lobbies", %{conn: conn} do
+      # Insert a couple of lobbies for the purpose of the test
+      {:ok, lobby1} = LobbyContext.create_lobby(%{"name" => "lobby1", "status" => "open"})
+      {:ok, lobby2} = LobbyContext.create_lobby(%{"name" => "lobby2", "status" => "closed"})
+
+      # Make the request
+      conn = get(conn, "/api/lobbies")
+
+      # Check the response
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body) == [
+        %{ "id" => lobby1.id, "name" => "lobby1", "status" => "open"},
+        %{ "id" => lobby2.id, "name" => "lobby2", "status" => "closed"},
+      ]
+    end
+  end
+
+  describe "create lobby" do
+    test "returns 201 and lobby when data is valid", %{conn: conn} do
+      conn = post(conn, "/api/lobbies", lobby: @valid_attrs)
+
+      # for some reason the id is incrementing on every test run
+      # it would be nice to figure out how to reset the db between tests
+      assert conn.status == 201
+      response_body = Jason.decode!(conn.resp_body)
+      assert response_body["name"] == "my cool lobby"
+      assert response_body["status"] == "open"
+    end
+
+    test "returns 422 when data is invalid", %{conn: conn} do
+      conn = post(conn, "/api/lobbies", lobby: @invalid_attrs)
+
+      assert %{status: 422} = conn
+    end
+  end
+end

--- a/mf_backend/test/support/fixtures/lobby_context_fixtures.ex
+++ b/mf_backend/test/support/fixtures/lobby_context_fixtures.ex
@@ -1,0 +1,21 @@
+defmodule MfBackend.LobbyContextFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `MfBackend.LobbyContext` context.
+  """
+
+  @doc """
+  Generate a lobby.
+  """
+  def lobby_fixture(attrs \\ %{}) do
+    {:ok, lobby} =
+      attrs
+      |> Enum.into(%{
+        name: "some name",
+        status: "some status"
+      })
+      |> MfBackend.LobbyContext.create_lobby()
+
+    lobby
+  end
+end


### PR DESCRIPTION
This PR sets up the initial schema for `lobbies` which will facilitate managing the game rooms (channel topics) that clients are connected to.

# Changes
- Setups up the initial schema for lobbies
- Adds a migration for adding the table to the database
- Adds a context for grouping schema related operations
- Adds routes for getting all lobbies and creating new lobbies

OOS:
- Setting up channel and subscribing to topics per lobby
- Deleting lobbies
- Getting lobbies via id

## Demos
![image](https://github.com/gsavchenko/MazeFaze/assets/9406280/76829b0d-7cae-4d9d-ad0e-b0a773eb81a2)
![image](https://github.com/gsavchenko/MazeFaze/assets/9406280/c63687e4-c65a-4f45-9804-e5772805957a)
