### PR TITLE
adding original paths mapping back

### DIFF
--- a/mf_frontend/tsconfig.json
+++ b/mf_frontend/tsconfig.json
@@ -21,7 +21,10 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
resolves #12 

It appears that there have been substantial modifications to the compiler options in your branch which cased this error to occur.

If we take a look at the Next js [documentation](https://nextjs.org/docs/app/building-your-application/configuring/absolute-imports-and-module-aliases) for absolute imports it states the following:

[Module Aliases](https://nextjs.org/docs/app/building-your-application/configuring/absolute-imports-and-module-aliases#module-aliases)
> In addition to configuring the baseUrl path, you can use the "paths" option to "alias" module paths.
> For example, the following configuration maps @/components/* to components/*:

By adding the original `paths` configuration option your branch is able to resolve @/features again.